### PR TITLE
Add a flash storage "gatewayOf"

### DIFF
--- a/contracts/SwapAndStakeV2.sol
+++ b/contracts/SwapAndStakeV2.sol
@@ -11,6 +11,7 @@ contract SwapAndStakeV2 is Escrow {
 	address public devAddress;
 	address public lockupAddress;
 	address public sTokensAddress;
+	mapping(bytes32 => bool) public isExecuting;
 	IUniswapV2Router02 public uniswapRouter;
 
 	constructor(

--- a/contracts/SwapAndStakeV2.sol
+++ b/contracts/SwapAndStakeV2.sol
@@ -11,7 +11,11 @@ contract SwapAndStakeV2 is Escrow {
 	address public devAddress;
 	address public lockupAddress;
 	address public sTokensAddress;
-	mapping(bytes32 => bool) public isExecuting;
+	struct Amounts {
+		uint256 input;
+		uint256 fee;
+	}
+	mapping(address => Amounts) public gatewayOf;
 	IUniswapV2Router02 public uniswapRouter;
 
 	constructor(

--- a/contracts/SwapAndStakeV2L1.sol
+++ b/contracts/SwapAndStakeV2L1.sol
@@ -32,7 +32,11 @@ contract SwapAndStakeV2L1 is SwapAndStakeV2 {
 		uint256 deadline,
 		bytes32 payload
 	) external payable {
+		gatewayOf[address(0)] = Amounts(msg.value, 0);
+
 		_swapEthAndStakeDev(msg.value, property, deadline, payload);
+
+		delete gatewayOf[address(0)];
 	}
 
 	/// @notice Swap eth -> dev and stake with GATEWAY FEE (paid in ETH) and payload
@@ -54,12 +58,16 @@ contract SwapAndStakeV2L1 is SwapAndStakeV2 {
 		uint256 feeAmount = (msg.value * gatewayFee) / 10000;
 		_deposit(gatewayAddress, feeAmount, address(0));
 
+		gatewayOf[gatewayAddress] = Amounts(msg.value, feeAmount);
+
 		_swapEthAndStakeDev(
 			(msg.value - feeAmount),
 			property,
 			deadline,
 			payload
 		);
+
+		delete gatewayOf[gatewayAddress];
 	}
 
 	/// @notice get estimated DEV output from ETH input
@@ -111,9 +119,6 @@ contract SwapAndStakeV2L1 is SwapAndStakeV2 {
 		uint256 deadline,
 		bytes32 payload
 	) internal virtual {
-		bytes32 txData = keccak256(msg.data);
-		isExecuting[txData] = true;
-
 		uint256[] memory amounts = uniswapRouter.swapExactETHForTokens{
 			value: amount
 		}(1, _getPathForEthToDev(), address(this), deadline);
@@ -128,7 +133,5 @@ contract SwapAndStakeV2L1 is SwapAndStakeV2 {
 			msg.sender,
 			tokenId
 		);
-
-		delete isExecuting[txData];
 	}
 }

--- a/contracts/SwapAndStakeV2L1.sol
+++ b/contracts/SwapAndStakeV2L1.sol
@@ -111,6 +111,9 @@ contract SwapAndStakeV2L1 is SwapAndStakeV2 {
 		uint256 deadline,
 		bytes32 payload
 	) internal virtual {
+		bytes32 txData = keccak256(msg.data);
+		isExecuting[txData] = true;
+
 		uint256[] memory amounts = uniswapRouter.swapExactETHForTokens{
 			value: amount
 		}(1, _getPathForEthToDev(), address(this), deadline);
@@ -125,5 +128,7 @@ contract SwapAndStakeV2L1 is SwapAndStakeV2 {
 			msg.sender,
 			tokenId
 		);
+
+		delete isExecuting[txData];
 	}
 }

--- a/contracts/SwapAndStakeV2Polygon.sol
+++ b/contracts/SwapAndStakeV2Polygon.sol
@@ -42,7 +42,12 @@ contract SwapAndStakeV2Polygon is SwapAndStakeV2 {
 	) external {
 		// Transfer the amount from the user to the contract
 		IERC20(wethAddress).transferFrom(msg.sender, address(this), amount);
+
+		gatewayOf[address(0)] = Amounts(amount, 0);
+
 		_swapEthAndStakeDev(amount, property, deadline, payload);
+
+		delete gatewayOf[address(0)];
 	}
 
 	/// @notice Swap weth -> wmatic -> dev and stake
@@ -67,7 +72,11 @@ contract SwapAndStakeV2Polygon is SwapAndStakeV2 {
 		uint256 feeAmount = (amount * gatewayFee) / 10000;
 		_deposit(gatewayAddress, feeAmount, wethAddress);
 
+		gatewayOf[gatewayAddress] = Amounts(amount, feeAmount);
+
 		_swapEthAndStakeDev((amount - feeAmount), property, deadline, payload);
+
+		delete gatewayOf[gatewayAddress];
 	}
 
 	/// @notice get estimated DEV output from ETH input
@@ -115,9 +124,6 @@ contract SwapAndStakeV2Polygon is SwapAndStakeV2 {
 		uint256 deadline,
 		bytes32 payload
 	) internal {
-		bytes32 txData = keccak256(msg.data);
-		isExecuting[txData] = true;
-
 		// Approve weth to be sent to Uniswap Router
 		IERC20(wethAddress).approve(address(uniswapRouter), amount);
 
@@ -146,7 +152,5 @@ contract SwapAndStakeV2Polygon is SwapAndStakeV2 {
 			msg.sender,
 			tokenId
 		);
-
-		delete isExecuting[txData];
 	}
 }

--- a/contracts/SwapAndStakeV2Polygon.sol
+++ b/contracts/SwapAndStakeV2Polygon.sol
@@ -115,6 +115,9 @@ contract SwapAndStakeV2Polygon is SwapAndStakeV2 {
 		uint256 deadline,
 		bytes32 payload
 	) internal {
+		bytes32 txData = keccak256(msg.data);
+		isExecuting[txData] = true;
+
 		// Approve weth to be sent to Uniswap Router
 		IERC20(wethAddress).approve(address(uniswapRouter), amount);
 
@@ -143,5 +146,7 @@ contract SwapAndStakeV2Polygon is SwapAndStakeV2 {
 			msg.sender,
 			tokenId
 		);
+
+		delete isExecuting[txData];
 	}
 }

--- a/contracts/SwapAndStakeV3.sol
+++ b/contracts/SwapAndStakeV3.sol
@@ -20,7 +20,11 @@ contract SwapAndStakeV3 {
 	address public devAddress;
 	address public lockupAddress;
 	address public sTokensAddress;
-	mapping(bytes32 => bool) public isExecuting;
+	struct Amounts {
+		uint256 input;
+		uint256 fee;
+	}
+	mapping(address => Amounts) public gatewayOf;
 
 	constructor(
 		address _wethAddress,
@@ -37,8 +41,7 @@ contract SwapAndStakeV3 {
 	function swapEthAndStakeDev(address property) external payable {
 		require(msg.value > 0, "Must pass non 0 ETH amount");
 
-		bytes32 txData = keccak256(msg.data);
-		isExecuting[txData] = true;
+		gatewayOf[address(0)] = Amounts(msg.value, 0);
 
 		// solhint-disable-next-line not-rely-on-time
 		uint256 deadline = block.timestamp + 15; // using 'now' for convenience, for mainnet pass deadline from frontend!
@@ -76,7 +79,7 @@ contract SwapAndStakeV3 {
 			tokenId
 		);
 
-		delete isExecuting[txData];
+		delete gatewayOf[address(0)];
 	}
 
 	// do not used on-chain, gas inefficient!

--- a/contracts/SwapAndStakeV3.sol
+++ b/contracts/SwapAndStakeV3.sol
@@ -20,6 +20,7 @@ contract SwapAndStakeV3 {
 	address public devAddress;
 	address public lockupAddress;
 	address public sTokensAddress;
+	mapping(bytes32 => bool) public isExecuting;
 
 	constructor(
 		address _wethAddress,
@@ -35,6 +36,9 @@ contract SwapAndStakeV3 {
 
 	function swapEthAndStakeDev(address property) external payable {
 		require(msg.value > 0, "Must pass non 0 ETH amount");
+
+		bytes32 txData = keccak256(msg.data);
+		isExecuting[txData] = true;
 
 		// solhint-disable-next-line not-rely-on-time
 		uint256 deadline = block.timestamp + 15; // using 'now' for convenience, for mainnet pass deadline from frontend!
@@ -71,6 +75,8 @@ contract SwapAndStakeV3 {
 			msg.sender,
 			tokenId
 		);
+
+		delete isExecuting[txData];
 	}
 
 	// do not used on-chain, gas inefficient!


### PR DESCRIPTION
ETH/WETH deposit amount and struct (Amounts) by gateway fee are stored in a map keyed by the gateway address (or zero address) and deleted at the end of the transaction.

This allows user-defined contracts such as Dynamic sTokens to validate that the gateway is functioning as expected. For example, the creator can validate staking ok/ng by testing that the expected fee is deposited to the expected gateway address.