### PR TITLE
Ecosystem fee: SwapTokensAndStakeDev contract will deposit (_deposit) 2.5% of the transferred value to the owner if the gatewayFee is greater than or equal to 85% (= Staking ratio of 15% or less).

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           touch .env
           echo MNEMONIC=${{ secrets.MNEMONIC }} >> .env
-          echo INFURA_KEY=${{ secrets.ALCHEMY_KEY }} >> .env
+          echo ALCHEMY_KEY=${{ secrets.ALCHEMY_KEY }} >> .env
 
       - name: install deps
         run: yarn

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           touch .env
           echo MNEMONIC=${{ secrets.MNEMONIC }} >> .env
-          echo INFURA_KEY=${{ secrets.INFURA_KEY }} >> .env
+          echo INFURA_KEY=${{ secrets.ALCHEMY_KEY }} >> .env
 
       - name: install deps
         run: yarn

--- a/contracts/SwapTokensAndStakeDev.sol
+++ b/contracts/SwapTokensAndStakeDev.sol
@@ -36,6 +36,8 @@ contract SwapTokensAndStakeDev is Escrow, Initializable {
 	mapping(address => Amounts) public gatewayOf;
 	mapping(bytes32 => EnumerableSetUpgradeable.AddressSet) private _roles;
 	address public owner;
+	uint256 public ecosystemFee;
+	uint256 public ecosystemFeeThreshold;
 
 	function initialize(
 		address _devAddress,
@@ -80,6 +82,17 @@ contract SwapTokensAndStakeDev is Escrow, Initializable {
 
 	function CALL_MINTFOR_ROLE() public pure returns (bytes32) {
 		return keccak256("ROLE.CALL_MINTFOR");
+	}
+
+	function updateEcosystemFee(uint256 _ecosystemFee) public onlyOwner {
+		ecosystemFee = _ecosystemFee;
+	}
+
+	function updateEcosystemFeeThreshold(uint256 _ecosystemFeeThreshold)
+		public
+		onlyOwner
+	{
+		ecosystemFeeThreshold = _ecosystemFeeThreshold;
 	}
 
 	/// @notice Protection for path should be made at front-end such that dev is final output token

--- a/contracts/SwapTokensAndStakeDev.sol
+++ b/contracts/SwapTokensAndStakeDev.sol
@@ -155,7 +155,8 @@ contract SwapTokensAndStakeDev is Escrow, Initializable {
 
 		uint256 feeAmount = (msg.value * _gatewayFee) / 10000;
 
-		uint256 acutualFeeAmount = ((msg.value - ecosystemFeeAmount) * _gatewayFee) / 10000;
+		uint256 acutualFeeAmount = ((msg.value - ecosystemFeeAmount) *
+			_gatewayFee) / 10000;
 
 		_deposit(owner, ecosystemFeeAmount, address(0));
 		_deposit(_gatewayAddress, acutualFeeAmount, address(0));
@@ -274,7 +275,7 @@ contract SwapTokensAndStakeDev is Escrow, Initializable {
 		// handle acutual gateway fee
 		uint256 acutualFeeAmount = ((_amount - ecosystemFeeAmount) *
 			_gatewayFee) / 10000;
-		
+
 		_deposit(owner, ecosystemFeeAmount, address(_token));
 		_deposit(_gatewayAddress, acutualFeeAmount, address(_token));
 

--- a/contracts/SwapTokensAndStakeDev.sol
+++ b/contracts/SwapTokensAndStakeDev.sol
@@ -88,10 +88,9 @@ contract SwapTokensAndStakeDev is Escrow, Initializable {
 		ecosystemFee = _ecosystemFee;
 	}
 
-	function updateEcosystemFeeThreshold(uint256 _ecosystemFeeThreshold)
-		public
-		onlyOwner
-	{
+	function updateEcosystemFeeThreshold(
+		uint256 _ecosystemFeeThreshold
+	) public onlyOwner {
 		ecosystemFeeThreshold = _ecosystemFeeThreshold;
 	}
 

--- a/contracts/SwapTokensAndStakeDev.sol
+++ b/contracts/SwapTokensAndStakeDev.sol
@@ -147,7 +147,7 @@ contract SwapTokensAndStakeDev is Escrow, Initializable {
 		uint256 _gatewayFee
 	) external payable {
 		require(msg.value > 0, "Must pass non-zero amount");
-		require(_gatewayFee < 10000, "must be below 10000");
+		require(_gatewayFee <= 10000, "must be below or equal 10000");
 		// handle fee
 		uint256 feeAmount = (msg.value * _gatewayFee) / 10000;
 		_deposit(_gatewayAddress, feeAmount, address(0));
@@ -240,7 +240,7 @@ contract SwapTokensAndStakeDev is Escrow, Initializable {
 		address payable _gatewayAddress,
 		uint256 _gatewayFee
 	) external {
-		require(_gatewayFee < 10000, "must be below 10000");
+		require(_gatewayFee <= 10000, "must be below or equal 10000");
 		require(
 			_token.allowance(msg.sender, address(this)) >= _amount,
 			"insufficient allowance"

--- a/contracts/SwapTokensAndStakeDev.sol
+++ b/contracts/SwapTokensAndStakeDev.sol
@@ -149,8 +149,16 @@ contract SwapTokensAndStakeDev is Escrow, Initializable {
 		require(msg.value > 0, "Must pass non-zero amount");
 		require(_gatewayFee <= 10000, "must be below or equal 10000");
 		// handle fee
+		uint256 ecosystemFeeAmount = _gatewayFee >= ecosystemFeeThreshold
+			? (msg.value * ecosystemFee) / 10000
+			: 0;
+
 		uint256 feeAmount = (msg.value * _gatewayFee) / 10000;
-		_deposit(_gatewayAddress, feeAmount, address(0));
+
+		uint256 acutualFeeAmount = ((msg.value - ecosystemFeeAmount) * _gatewayFee) / 10000;
+
+		_deposit(owner, ecosystemFeeAmount, address(0));
+		_deposit(_gatewayAddress, acutualFeeAmount, address(0));
 
 		gatewayOf[_gatewayAddress] = Amounts(address(0), msg.value, feeAmount);
 
@@ -158,7 +166,7 @@ contract SwapTokensAndStakeDev is Escrow, Initializable {
 			_to,
 			_path,
 			_property,
-			(msg.value - feeAmount),
+			(msg.value - ecosystemFeeAmount - acutualFeeAmount),
 			_amountOut,
 			_deadline,
 			_payload
@@ -256,9 +264,19 @@ contract SwapTokensAndStakeDev is Escrow, Initializable {
 			address(this),
 			_amount
 		);
+
+		uint256 ecosystemFeeAmount = _gatewayFee >= ecosystemFeeThreshold
+			? (_amount * ecosystemFee) / 10000
+			: 0;
+
 		// handle fee
 		uint256 feeAmount = (_amount * _gatewayFee) / 10000;
-		_deposit(_gatewayAddress, feeAmount, address(_token));
+		// handle acutual gateway fee
+		uint256 acutualFeeAmount = ((_amount - ecosystemFeeAmount) *
+			_gatewayFee) / 10000;
+		
+		_deposit(owner, ecosystemFeeAmount, address(_token));
+		_deposit(_gatewayAddress, acutualFeeAmount, address(_token));
 
 		gatewayOf[_gatewayAddress] = Amounts(
 			address(_token),
@@ -271,7 +289,7 @@ contract SwapTokensAndStakeDev is Escrow, Initializable {
 			_token,
 			_path,
 			_property,
-			(_amount - feeAmount),
+			(_amount - ecosystemFeeAmount - acutualFeeAmount),
 			_amountOut,
 			_deadline,
 			_payload

--- a/test/swap-stake-v2-mainnet.ts
+++ b/test/swap-stake-v2-mainnet.ts
@@ -9,7 +9,7 @@ import * as dotenv from 'dotenv'
 dotenv.config()
 
 const RPC_KEY =
-	typeof process.env.INFURA_KEY === 'undefined' ? '' : process.env.INFURA_KEY
+	typeof process.env.ALCHEMY_KEY === 'undefined' ? '' : process.env.ALCHEMY_KEY
 
 use(solidity)
 
@@ -27,11 +27,10 @@ describe('SwapAndStakeV2 Mainnet', () => {
 	const sTokensManagerAddress = '0x50489Ff5f879A44C87bBA85287729D663b18CeD5'
 
 	beforeEach(async function () {
-		this.timeout(60000)
 		await ethers.provider.send('hardhat_reset', [
 			{
 				forking: {
-					jsonRpcUrl: 'https://mainnet.infura.io/v3/' + RPC_KEY,
+					jsonRpcUrl: 'https://eth-mainnet.g.alchemy.com/v2/' + RPC_KEY,
 					blockNumber: 15126211,
 				},
 			},
@@ -59,6 +58,7 @@ describe('SwapAndStakeV2 Mainnet', () => {
 			'ISTokensManager',
 			sTokensManagerAddress
 		)
+		this.timeout(60000)
 	})
 	describe('swap eth for dev', () => {
 		it('should stake eth for dev without gateway fee', async () => {

--- a/test/swap-stake-v2-mainnet.ts
+++ b/test/swap-stake-v2-mainnet.ts
@@ -26,7 +26,8 @@ describe('SwapAndStakeV2 Mainnet', () => {
 	const propertyAddress = '0xac1AC9d00314aE7B4a7d6DbEE4860bECedF92309'
 	const sTokensManagerAddress = '0x50489Ff5f879A44C87bBA85287729D663b18CeD5'
 
-	beforeEach(async () => {
+	beforeEach(async function () {
+		this.timeout(60000)
 		await ethers.provider.send('hardhat_reset', [
 			{
 				forking: {

--- a/test/swap-stake-v2-quickswap.ts
+++ b/test/swap-stake-v2-quickswap.ts
@@ -10,7 +10,6 @@ dotenv.config()
 const RPC_KEY =
 	typeof process.env.ALCHEMY_KEY === 'undefined' ? '' : process.env.ALCHEMY_KEY
 
-
 use(solidity)
 
 describe('SwapAndStakeV2 Quickswap', () => {
@@ -34,9 +33,8 @@ describe('SwapAndStakeV2 Quickswap', () => {
 		await ethers.provider.send('hardhat_reset', [
 			{
 				forking: {
-					jsonRpcUrl:
-						'https://polygon-mainnet.g.alchemy.com/v2/' + RPC_KEY,
-						blocknumber:30632152
+					jsonRpcUrl: 'https://polygon-mainnet.g.alchemy.com/v2/' + RPC_KEY,
+					blocknumber: 30632152,
 				},
 			},
 		])

--- a/test/swap-stake-v2-quickswap.ts
+++ b/test/swap-stake-v2-quickswap.ts
@@ -7,6 +7,9 @@ import { Contract, BigNumber } from 'ethers'
 import * as dotenv from 'dotenv'
 
 dotenv.config()
+const RPC_KEY =
+	typeof process.env.ALCHEMY_KEY === 'undefined' ? '' : process.env.ALCHEMY_KEY
+
 
 use(solidity)
 
@@ -28,13 +31,12 @@ describe('SwapAndStakeV2 Quickswap', () => {
 	let router: Contract
 
 	beforeEach(async function () {
-		this.timeout(60000)
 		await ethers.provider.send('hardhat_reset', [
 			{
 				forking: {
 					jsonRpcUrl:
-						'https://polygon-mainnet.infura.io/v3/265bfd78394d426694f7c749be00f7fc',
-					blockNumber: 30632152,
+						'https://polygon-mainnet.g.alchemy.com/v2/' + RPC_KEY,
+						blocknumber:30632152
 				},
 			},
 		])
@@ -79,6 +81,7 @@ describe('SwapAndStakeV2 Quickswap', () => {
 			],
 			account1
 		)
+		this.timeout(60000)
 	})
 	describe('swap eth for dev', () => {
 		it('should stake eth for dev', async () => {

--- a/test/swap-stake-v2-quickswap.ts
+++ b/test/swap-stake-v2-quickswap.ts
@@ -27,7 +27,8 @@ describe('SwapAndStakeV2 Quickswap', () => {
 	let wethContract: Contract
 	let router: Contract
 
-	beforeEach(async () => {
+	beforeEach(async function () {
+		this.timeout(60000)
 		await ethers.provider.send('hardhat_reset', [
 			{
 				forking: {

--- a/test/swap-stake-v3-arbitrum.ts
+++ b/test/swap-stake-v3-arbitrum.ts
@@ -27,7 +27,8 @@ describe('SwapAndStakeV3 Arbitrum', () => {
 	const propertyAddress = '0x7645306DfB9e14C0B849bb71eeC7BB4D1Cde8251'
 	const sTokensManagerAddress = '0x40d999931f7055F670511860e24624939e71a96a'
 
-	beforeEach(async () => {
+	beforeEach(async function () {
+		this.timeout(60000)
 		await ethers.provider.send('hardhat_reset', [
 			{
 				forking: {

--- a/test/swap-stake-v3-arbitrum.ts
+++ b/test/swap-stake-v3-arbitrum.ts
@@ -9,7 +9,7 @@ import * as dotenv from 'dotenv'
 dotenv.config()
 
 const RPC_KEY =
-	typeof process.env.INFURA_KEY === 'undefined' ? '' : process.env.INFURA_KEY
+	typeof process.env.ALCHEMY_KEY === 'undefined' ? '' : process.env.ALCHEMY_KEY
 
 use(solidity)
 
@@ -27,13 +27,12 @@ describe('SwapAndStakeV3 Arbitrum', () => {
 	const propertyAddress = '0x7645306DfB9e14C0B849bb71eeC7BB4D1Cde8251'
 	const sTokensManagerAddress = '0x40d999931f7055F670511860e24624939e71a96a'
 
-	beforeEach(async function () {
-		this.timeout(60000)
+	beforeEach(async () => {
 		await ethers.provider.send('hardhat_reset', [
 			{
 				forking: {
-					jsonRpcUrl: 'https://arbitrum-mainnet.infura.io/v3/' + RPC_KEY,
-					blockNumber: 54992509,
+					jsonRpcUrl: 'https://arb-mainnet.g.alchemy.com/v2/' + RPC_KEY,
+					blockNumber: 225577784,
 				},
 			},
 		])

--- a/test/swap-stake-v3-polygon.ts
+++ b/test/swap-stake-v3-polygon.ts
@@ -10,7 +10,6 @@ dotenv.config()
 const RPC_KEY =
 	typeof process.env.ALCHEMY_KEY === 'undefined' ? '' : process.env.ALCHEMY_KEY
 
-
 use(solidity)
 
 describe('SwapAndStakeV3 Polygon', () => {
@@ -31,13 +30,12 @@ describe('SwapAndStakeV3 Polygon', () => {
 	let wethContract: Contract
 	let swapRouter: ISwapRouter
 
-	beforeEach(async  () => {
+	beforeEach(async () => {
 		await ethers.provider.send('hardhat_reset', [
 			{
 				forking: {
-					jsonRpcUrl:
-						'https://polygon-mainnet.g.alchemy.com/v2/' + RPC_KEY,
-						blockNumber: 58590400,
+					jsonRpcUrl: 'https://polygon-mainnet.g.alchemy.com/v2/' + RPC_KEY,
+					blockNumber: 58590400,
 				},
 			},
 		])

--- a/test/swap-stake-v3-polygon.ts
+++ b/test/swap-stake-v3-polygon.ts
@@ -28,7 +28,8 @@ describe('SwapAndStakeV3 Polygon', () => {
 	let wethContract: Contract
 	let swapRouter: ISwapRouter
 
-	beforeEach(async () => {
+	beforeEach(async function () {
+		this.timeout(60000)
 		await ethers.provider.send('hardhat_reset', [
 			{
 				forking: {

--- a/test/swap-stake-v3-polygon.ts
+++ b/test/swap-stake-v3-polygon.ts
@@ -7,6 +7,9 @@ import { type Contract, type BigNumber } from 'ethers'
 import * as dotenv from 'dotenv'
 
 dotenv.config()
+const RPC_KEY =
+	typeof process.env.ALCHEMY_KEY === 'undefined' ? '' : process.env.ALCHEMY_KEY
+
 
 use(solidity)
 
@@ -28,14 +31,13 @@ describe('SwapAndStakeV3 Polygon', () => {
 	let wethContract: Contract
 	let swapRouter: ISwapRouter
 
-	beforeEach(async function () {
-		this.timeout(60000)
+	beforeEach(async  () => {
 		await ethers.provider.send('hardhat_reset', [
 			{
 				forking: {
 					jsonRpcUrl:
-						'https://polygon-mainnet.infura.io/v3/265bfd78394d426694f7c749be00f7fc',
-					blockNumber: 38383175,
+						'https://polygon-mainnet.g.alchemy.com/v2/' + RPC_KEY,
+						blockNumber: 58590400,
 				},
 			},
 		])

--- a/test/swap-stake-v3.ts
+++ b/test/swap-stake-v3.ts
@@ -18,7 +18,8 @@ describe('SwapAndStakeV3 Arbitrum', () => {
 	const propertyAddress = '0x7645306DfB9e14C0B849bb71eeC7BB4D1Cde8251'
 	const sTokensManagerAddress = '0x40d999931f7055F670511860e24624939e71a96a'
 
-	beforeEach(async () => {
+	beforeEach(async function () {
+		this.timeout(60000)
 		const factory = await ethers.getContractFactory('SwapAndStakeV3')
 		swapAndStakeContract = (await factory.deploy(
 			wethAddress,

--- a/test/swap-stake-v3.ts
+++ b/test/swap-stake-v3.ts
@@ -19,7 +19,6 @@ describe('SwapAndStakeV3 Arbitrum', () => {
 	const sTokensManagerAddress = '0x40d999931f7055F670511860e24624939e71a96a'
 
 	beforeEach(async function () {
-		this.timeout(60000)
 		const factory = await ethers.getContractFactory('SwapAndStakeV3')
 		swapAndStakeContract = (await factory.deploy(
 			wethAddress,
@@ -28,6 +27,7 @@ describe('SwapAndStakeV3 Arbitrum', () => {
 			sTokensManagerAddress
 		)) as SwapAndStakeV3
 		await swapAndStakeContract.deployed()
+		this.timeout(60000)
 	})
 	describe('swap eth for dev', () => {
 		it('should revert when sending 0 ETH', async () => {

--- a/test/swap-tokens-stake-dev.ts
+++ b/test/swap-tokens-stake-dev.ts
@@ -46,9 +46,8 @@ describe('SwapTokensAndStakeDev', () => {
 		await ethers.provider.send('hardhat_reset', [
 			{
 				forking: {
-					jsonRpcUrl:
-						'https://polygon-mainnet.g.alchemy.com/v2/' + RPC_KEY,
-						blockNumber: 58590400,
+					jsonRpcUrl: 'https://polygon-mainnet.g.alchemy.com/v2/' + RPC_KEY,
+					blockNumber: 58590400,
 				},
 			},
 		])

--- a/test/swap-tokens-stake-dev.ts
+++ b/test/swap-tokens-stake-dev.ts
@@ -39,7 +39,8 @@ describe('SwapTokensAndStakeDev', () => {
 	let usdcContract: Contract
 	let swapRouter: ISwapRouter
 
-	beforeEach(async () => {
+	beforeEach(async function () {
+		this.timeout(60000);
 		await ethers.provider.send('hardhat_reset', [
 			{
 				forking: {
@@ -197,8 +198,10 @@ describe('SwapTokensAndStakeDev', () => {
 				const block = await waffle.provider.getBlock('latest')
 				const deadline = block.timestamp + 300
 
-				const [cont, owner, admin] =
-					await deployWithProxy<SwapTokensAndStakeDev>('SwapTokensAndStakeDev')
+
+				const [cont, owner, admin] = await deployWithProxy<SwapTokensAndStakeDev>(
+					'SwapTokensAndStakeDev'
+				)
 				await cont.initialize(devAddress, lockupAddress, sTokensManagerAddress)
 
 				const owner1 = await cont.owner()
@@ -230,9 +233,7 @@ describe('SwapTokensAndStakeDev', () => {
 					}
 				)
 				await cont.connect(contractOwner).updateEcosystemFee(ecosystemFee)
-				await cont
-					.connect(contractOwner)
-					.updateEcosystemFeeThreshold(ecosystemFeeThreshold)
+				await cont.connect(contractOwner).updateEcosystemFeeThreshold(ecosystemFeeThreshold)
 
 				// Approve USDC
 				await usdcContract
@@ -241,14 +242,8 @@ describe('SwapTokensAndStakeDev', () => {
 
 				const gatewayFeeBasisPoints = 333 // In basis points, so 3.33%
 				const depositAmount = ethers.utils.parseUnits('1', 6)
-				const ecosystemFeeAmount =
-					gatewayFeeBasisPoints >= ecosystemFeeThreshold
-						? depositAmount.mul(ecosystemFee).div(10000)
-						: 0
-				const acutualFeeAmount = depositAmount
-					.sub(ecosystemFeeAmount)
-					.mul(gatewayFeeBasisPoints)
-					.div(10000)
+				const ecosystemFeeAmount = gatewayFeeBasisPoints >= ecosystemFeeThreshold ? depositAmount.mul(ecosystemFee).div(10000) : 0
+				const acutualFeeAmount = (depositAmount.sub(ecosystemFeeAmount)).mul(gatewayFeeBasisPoints).div(10000)
 				const path: Path = {
 					token1: usdcAddress,
 					fee1: 500,
@@ -263,7 +258,7 @@ describe('SwapTokensAndStakeDev', () => {
 						['address', 'uint24', 'address', 'uint24', 'address'],
 						[path.token1, path.fee1, path.token2, path.fee2, path.token3]
 					),
-					depositAmount.sub(ecosystemFeeAmount).sub(acutualFeeAmount)
+					(depositAmount.sub(ecosystemFeeAmount)).sub(acutualFeeAmount)
 				)
 
 				const amountIn = await cont.callStatic.getEstimatedTokensForDev(
@@ -330,9 +325,11 @@ describe('SwapTokensAndStakeDev', () => {
 				const block = await waffle.provider.getBlock('latest')
 				const deadline = block.timestamp + 300
 
-				const [cont, owner, admin] =
-					await deployWithProxy<SwapTokensAndStakeDev>('SwapTokensAndStakeDev')
+				const [cont, owner, admin] = await deployWithProxy<SwapTokensAndStakeDev>(
+					'SwapTokensAndStakeDev'
+				)
 				await cont.initialize(devAddress, lockupAddress, sTokensManagerAddress)
+
 
 				const owner1 = await cont.owner()
 				expect(owner1).to.equal(ethers.constants.AddressZero)
@@ -363,9 +360,7 @@ describe('SwapTokensAndStakeDev', () => {
 					}
 				)
 				await cont.connect(contractOwner).updateEcosystemFee(ecosystemFee)
-				await cont
-					.connect(contractOwner)
-					.updateEcosystemFeeThreshold(ecosystemFeeThreshold)
+				await cont.connect(contractOwner).updateEcosystemFeeThreshold(ecosystemFeeThreshold)
 
 				// Approve USDC
 				await usdcContract
@@ -374,14 +369,8 @@ describe('SwapTokensAndStakeDev', () => {
 
 				const gatewayFeeBasisPoints = 8600 // In basis points, so 3.33%
 				const depositAmount = ethers.utils.parseUnits('1', 6)
-				const ecosystemFeeAmount =
-					gatewayFeeBasisPoints >= ecosystemFeeThreshold
-						? depositAmount.mul(ecosystemFee).div(10000)
-						: 0
-				const acutualFeeAmount = depositAmount
-					.sub(ecosystemFeeAmount)
-					.mul(gatewayFeeBasisPoints)
-					.div(10000)
+				const ecosystemFeeAmount = gatewayFeeBasisPoints >= ecosystemFeeThreshold ? depositAmount.mul(ecosystemFee).div(10000) : 0
+				const acutualFeeAmount = (depositAmount.sub(ecosystemFeeAmount)).mul(gatewayFeeBasisPoints).div(10000)
 				const path: Path = {
 					token1: usdcAddress,
 					fee1: 500,
@@ -396,7 +385,7 @@ describe('SwapTokensAndStakeDev', () => {
 						['address', 'uint24', 'address', 'uint24', 'address'],
 						[path.token1, path.fee1, path.token2, path.fee2, path.token3]
 					),
-					depositAmount.sub(ecosystemFeeAmount).sub(acutualFeeAmount)
+					(depositAmount.sub(ecosystemFeeAmount)).sub(acutualFeeAmount)
 				)
 
 				const amountIn = await cont.callStatic.getEstimatedTokensForDev(
@@ -533,17 +522,12 @@ describe('SwapTokensAndStakeDev', () => {
 				const depositAmount = ethers.utils.parseEther('1')
 				const ecosystemFee = 250 // In basis points, so 2.5%
 				const ecosystemFeeThreshold = 8500 // In basis points, so 85%
-				const ecosystemFeeAmount =
-					gatewayFeeBasisPoints >= ecosystemFeeThreshold
-						? depositAmount.mul(ecosystemFee).div(10000)
-						: 0
-				const acutualFeeAmount = depositAmount
-					.sub(ecosystemFeeAmount)
-					.mul(gatewayFeeBasisPoints)
-					.div(10000)
+				const ecosystemFeeAmount = gatewayFeeBasisPoints >= ecosystemFeeThreshold ? depositAmount.mul(ecosystemFee).div(10000) : 0
+				const acutualFeeAmount = (depositAmount.sub(ecosystemFeeAmount)).mul(gatewayFeeBasisPoints).div(10000)
 
-				const [cont, owner, admin] =
-					await deployWithProxy<SwapTokensAndStakeDev>('SwapTokensAndStakeDev')
+				const [cont, owner, admin] = await deployWithProxy<SwapTokensAndStakeDev>(
+					'SwapTokensAndStakeDev'
+				)
 				await cont.initialize(devAddress, lockupAddress, sTokensManagerAddress)
 
 				const owner1 = await cont.owner()
@@ -556,9 +540,7 @@ describe('SwapTokensAndStakeDev', () => {
 				const contractOwner = await ethers.getSigner(owner)
 
 				await cont.connect(contractOwner).updateEcosystemFee(ecosystemFee)
-				await cont
-					.connect(contractOwner)
-					.updateEcosystemFeeThreshold(ecosystemFeeThreshold)
+				await cont.connect(contractOwner).updateEcosystemFeeThreshold(ecosystemFeeThreshold)
 
 				const path: Path = {
 					token1: weth9,
@@ -574,7 +556,7 @@ describe('SwapTokensAndStakeDev', () => {
 						['address', 'uint24', 'address', 'uint24', 'address'],
 						[path.token1, path.fee1, path.token2, path.fee2, path.token3]
 					),
-					depositAmount.sub(ecosystemFeeAmount).sub(acutualFeeAmount)
+					(depositAmount.sub(ecosystemFeeAmount)).sub(acutualFeeAmount)
 				)
 
 				const amountIn = await cont.callStatic.getEstimatedTokensForDev(
@@ -630,11 +612,7 @@ describe('SwapTokensAndStakeDev', () => {
 				// Withdraw credit
 				await expect(cont.connect(gateway).claim(ethers.constants.AddressZero))
 					.to.emit(cont, 'Withdrawn')
-					.withArgs(
-						gateway.address,
-						ethers.constants.AddressZero,
-						acutualFeeAmount
-					)
+					.withArgs(gateway.address, ethers.constants.AddressZero, acutualFeeAmount)
 				// Check gateway credit has been deducted
 				expect(
 					await cont.gatewayFees(gateway.address, ethers.constants.AddressZero)
@@ -649,17 +627,12 @@ describe('SwapTokensAndStakeDev', () => {
 				const depositAmount = ethers.utils.parseEther('1')
 				const ecosystemFee = 250 // In basis points, so 2.5%
 				const ecosystemFeeThreshold = 8500 // In basis points, so 85%
-				const ecosystemFeeAmount =
-					gatewayFeeBasisPoints >= ecosystemFeeThreshold
-						? depositAmount.mul(ecosystemFee).div(10000)
-						: 0
-				const acutualFeeAmount = depositAmount
-					.sub(ecosystemFeeAmount)
-					.mul(gatewayFeeBasisPoints)
-					.div(10000)
+				const ecosystemFeeAmount = gatewayFeeBasisPoints >= ecosystemFeeThreshold ? depositAmount.mul(ecosystemFee).div(10000) : 0
+				const acutualFeeAmount = (depositAmount.sub(ecosystemFeeAmount)).mul(gatewayFeeBasisPoints).div(10000)
 
-				const [cont, owner, admin] =
-					await deployWithProxy<SwapTokensAndStakeDev>('SwapTokensAndStakeDev')
+				const [cont, owner, admin] = await deployWithProxy<SwapTokensAndStakeDev>(
+					'SwapTokensAndStakeDev'
+				)
 				await cont.initialize(devAddress, lockupAddress, sTokensManagerAddress)
 
 				const owner1 = await cont.owner()
@@ -672,9 +645,7 @@ describe('SwapTokensAndStakeDev', () => {
 				const contractOwner = await ethers.getSigner(owner)
 
 				await cont.connect(contractOwner).updateEcosystemFee(ecosystemFee)
-				await cont
-					.connect(contractOwner)
-					.updateEcosystemFeeThreshold(ecosystemFeeThreshold)
+				await cont.connect(contractOwner).updateEcosystemFeeThreshold(ecosystemFeeThreshold)
 
 				const path: Path = {
 					token1: weth9,
@@ -690,7 +661,7 @@ describe('SwapTokensAndStakeDev', () => {
 						['address', 'uint24', 'address', 'uint24', 'address'],
 						[path.token1, path.fee1, path.token2, path.fee2, path.token3]
 					),
-					depositAmount.sub(ecosystemFeeAmount).sub(acutualFeeAmount)
+					(depositAmount.sub(ecosystemFeeAmount)).sub(acutualFeeAmount)
 				)
 
 				const amountIn = await cont.callStatic.getEstimatedTokensForDev(
@@ -746,11 +717,7 @@ describe('SwapTokensAndStakeDev', () => {
 				// Withdraw credit
 				await expect(cont.connect(gateway).claim(ethers.constants.AddressZero))
 					.to.emit(cont, 'Withdrawn')
-					.withArgs(
-						gateway.address,
-						ethers.constants.AddressZero,
-						acutualFeeAmount
-					)
+					.withArgs(gateway.address, ethers.constants.AddressZero, acutualFeeAmount)
 				// Check gateway credit has been deducted
 				expect(
 					await cont.gatewayFees(gateway.address, ethers.constants.AddressZero)

--- a/test/swap-tokens-stake-dev.ts
+++ b/test/swap-tokens-stake-dev.ts
@@ -40,7 +40,7 @@ describe('SwapTokensAndStakeDev', () => {
 	let swapRouter: ISwapRouter
 
 	beforeEach(async function () {
-		this.timeout(60000);
+		this.timeout(60000)
 		await ethers.provider.send('hardhat_reset', [
 			{
 				forking: {
@@ -198,10 +198,8 @@ describe('SwapTokensAndStakeDev', () => {
 				const block = await waffle.provider.getBlock('latest')
 				const deadline = block.timestamp + 300
 
-
-				const [cont, owner, admin] = await deployWithProxy<SwapTokensAndStakeDev>(
-					'SwapTokensAndStakeDev'
-				)
+				const [cont, owner, admin] =
+					await deployWithProxy<SwapTokensAndStakeDev>('SwapTokensAndStakeDev')
 				await cont.initialize(devAddress, lockupAddress, sTokensManagerAddress)
 
 				const owner1 = await cont.owner()
@@ -233,7 +231,9 @@ describe('SwapTokensAndStakeDev', () => {
 					}
 				)
 				await cont.connect(contractOwner).updateEcosystemFee(ecosystemFee)
-				await cont.connect(contractOwner).updateEcosystemFeeThreshold(ecosystemFeeThreshold)
+				await cont
+					.connect(contractOwner)
+					.updateEcosystemFeeThreshold(ecosystemFeeThreshold)
 
 				// Approve USDC
 				await usdcContract
@@ -242,8 +242,14 @@ describe('SwapTokensAndStakeDev', () => {
 
 				const gatewayFeeBasisPoints = 333 // In basis points, so 3.33%
 				const depositAmount = ethers.utils.parseUnits('1', 6)
-				const ecosystemFeeAmount = gatewayFeeBasisPoints >= ecosystemFeeThreshold ? depositAmount.mul(ecosystemFee).div(10000) : 0
-				const acutualFeeAmount = (depositAmount.sub(ecosystemFeeAmount)).mul(gatewayFeeBasisPoints).div(10000)
+				const ecosystemFeeAmount =
+					gatewayFeeBasisPoints >= ecosystemFeeThreshold
+						? depositAmount.mul(ecosystemFee).div(10000)
+						: 0
+				const acutualFeeAmount = depositAmount
+					.sub(ecosystemFeeAmount)
+					.mul(gatewayFeeBasisPoints)
+					.div(10000)
 				const path: Path = {
 					token1: usdcAddress,
 					fee1: 500,
@@ -258,7 +264,7 @@ describe('SwapTokensAndStakeDev', () => {
 						['address', 'uint24', 'address', 'uint24', 'address'],
 						[path.token1, path.fee1, path.token2, path.fee2, path.token3]
 					),
-					(depositAmount.sub(ecosystemFeeAmount)).sub(acutualFeeAmount)
+					depositAmount.sub(ecosystemFeeAmount).sub(acutualFeeAmount)
 				)
 
 				const amountIn = await cont.callStatic.getEstimatedTokensForDev(
@@ -325,11 +331,9 @@ describe('SwapTokensAndStakeDev', () => {
 				const block = await waffle.provider.getBlock('latest')
 				const deadline = block.timestamp + 300
 
-				const [cont, owner, admin] = await deployWithProxy<SwapTokensAndStakeDev>(
-					'SwapTokensAndStakeDev'
-				)
+				const [cont, owner, admin] =
+					await deployWithProxy<SwapTokensAndStakeDev>('SwapTokensAndStakeDev')
 				await cont.initialize(devAddress, lockupAddress, sTokensManagerAddress)
-
 
 				const owner1 = await cont.owner()
 				expect(owner1).to.equal(ethers.constants.AddressZero)
@@ -360,7 +364,9 @@ describe('SwapTokensAndStakeDev', () => {
 					}
 				)
 				await cont.connect(contractOwner).updateEcosystemFee(ecosystemFee)
-				await cont.connect(contractOwner).updateEcosystemFeeThreshold(ecosystemFeeThreshold)
+				await cont
+					.connect(contractOwner)
+					.updateEcosystemFeeThreshold(ecosystemFeeThreshold)
 
 				// Approve USDC
 				await usdcContract
@@ -369,8 +375,14 @@ describe('SwapTokensAndStakeDev', () => {
 
 				const gatewayFeeBasisPoints = 8600 // In basis points, so 3.33%
 				const depositAmount = ethers.utils.parseUnits('1', 6)
-				const ecosystemFeeAmount = gatewayFeeBasisPoints >= ecosystemFeeThreshold ? depositAmount.mul(ecosystemFee).div(10000) : 0
-				const acutualFeeAmount = (depositAmount.sub(ecosystemFeeAmount)).mul(gatewayFeeBasisPoints).div(10000)
+				const ecosystemFeeAmount =
+					gatewayFeeBasisPoints >= ecosystemFeeThreshold
+						? depositAmount.mul(ecosystemFee).div(10000)
+						: 0
+				const acutualFeeAmount = depositAmount
+					.sub(ecosystemFeeAmount)
+					.mul(gatewayFeeBasisPoints)
+					.div(10000)
 				const path: Path = {
 					token1: usdcAddress,
 					fee1: 500,
@@ -385,7 +397,7 @@ describe('SwapTokensAndStakeDev', () => {
 						['address', 'uint24', 'address', 'uint24', 'address'],
 						[path.token1, path.fee1, path.token2, path.fee2, path.token3]
 					),
-					(depositAmount.sub(ecosystemFeeAmount)).sub(acutualFeeAmount)
+					depositAmount.sub(ecosystemFeeAmount).sub(acutualFeeAmount)
 				)
 
 				const amountIn = await cont.callStatic.getEstimatedTokensForDev(
@@ -522,12 +534,17 @@ describe('SwapTokensAndStakeDev', () => {
 				const depositAmount = ethers.utils.parseEther('1')
 				const ecosystemFee = 250 // In basis points, so 2.5%
 				const ecosystemFeeThreshold = 8500 // In basis points, so 85%
-				const ecosystemFeeAmount = gatewayFeeBasisPoints >= ecosystemFeeThreshold ? depositAmount.mul(ecosystemFee).div(10000) : 0
-				const acutualFeeAmount = (depositAmount.sub(ecosystemFeeAmount)).mul(gatewayFeeBasisPoints).div(10000)
+				const ecosystemFeeAmount =
+					gatewayFeeBasisPoints >= ecosystemFeeThreshold
+						? depositAmount.mul(ecosystemFee).div(10000)
+						: 0
+				const acutualFeeAmount = depositAmount
+					.sub(ecosystemFeeAmount)
+					.mul(gatewayFeeBasisPoints)
+					.div(10000)
 
-				const [cont, owner, admin] = await deployWithProxy<SwapTokensAndStakeDev>(
-					'SwapTokensAndStakeDev'
-				)
+				const [cont, owner, admin] =
+					await deployWithProxy<SwapTokensAndStakeDev>('SwapTokensAndStakeDev')
 				await cont.initialize(devAddress, lockupAddress, sTokensManagerAddress)
 
 				const owner1 = await cont.owner()
@@ -540,7 +557,9 @@ describe('SwapTokensAndStakeDev', () => {
 				const contractOwner = await ethers.getSigner(owner)
 
 				await cont.connect(contractOwner).updateEcosystemFee(ecosystemFee)
-				await cont.connect(contractOwner).updateEcosystemFeeThreshold(ecosystemFeeThreshold)
+				await cont
+					.connect(contractOwner)
+					.updateEcosystemFeeThreshold(ecosystemFeeThreshold)
 
 				const path: Path = {
 					token1: weth9,
@@ -556,7 +575,7 @@ describe('SwapTokensAndStakeDev', () => {
 						['address', 'uint24', 'address', 'uint24', 'address'],
 						[path.token1, path.fee1, path.token2, path.fee2, path.token3]
 					),
-					(depositAmount.sub(ecosystemFeeAmount)).sub(acutualFeeAmount)
+					depositAmount.sub(ecosystemFeeAmount).sub(acutualFeeAmount)
 				)
 
 				const amountIn = await cont.callStatic.getEstimatedTokensForDev(
@@ -612,7 +631,11 @@ describe('SwapTokensAndStakeDev', () => {
 				// Withdraw credit
 				await expect(cont.connect(gateway).claim(ethers.constants.AddressZero))
 					.to.emit(cont, 'Withdrawn')
-					.withArgs(gateway.address, ethers.constants.AddressZero, acutualFeeAmount)
+					.withArgs(
+						gateway.address,
+						ethers.constants.AddressZero,
+						acutualFeeAmount
+					)
 				// Check gateway credit has been deducted
 				expect(
 					await cont.gatewayFees(gateway.address, ethers.constants.AddressZero)
@@ -627,12 +650,17 @@ describe('SwapTokensAndStakeDev', () => {
 				const depositAmount = ethers.utils.parseEther('1')
 				const ecosystemFee = 250 // In basis points, so 2.5%
 				const ecosystemFeeThreshold = 8500 // In basis points, so 85%
-				const ecosystemFeeAmount = gatewayFeeBasisPoints >= ecosystemFeeThreshold ? depositAmount.mul(ecosystemFee).div(10000) : 0
-				const acutualFeeAmount = (depositAmount.sub(ecosystemFeeAmount)).mul(gatewayFeeBasisPoints).div(10000)
+				const ecosystemFeeAmount =
+					gatewayFeeBasisPoints >= ecosystemFeeThreshold
+						? depositAmount.mul(ecosystemFee).div(10000)
+						: 0
+				const acutualFeeAmount = depositAmount
+					.sub(ecosystemFeeAmount)
+					.mul(gatewayFeeBasisPoints)
+					.div(10000)
 
-				const [cont, owner, admin] = await deployWithProxy<SwapTokensAndStakeDev>(
-					'SwapTokensAndStakeDev'
-				)
+				const [cont, owner, admin] =
+					await deployWithProxy<SwapTokensAndStakeDev>('SwapTokensAndStakeDev')
 				await cont.initialize(devAddress, lockupAddress, sTokensManagerAddress)
 
 				const owner1 = await cont.owner()
@@ -645,7 +673,9 @@ describe('SwapTokensAndStakeDev', () => {
 				const contractOwner = await ethers.getSigner(owner)
 
 				await cont.connect(contractOwner).updateEcosystemFee(ecosystemFee)
-				await cont.connect(contractOwner).updateEcosystemFeeThreshold(ecosystemFeeThreshold)
+				await cont
+					.connect(contractOwner)
+					.updateEcosystemFeeThreshold(ecosystemFeeThreshold)
 
 				const path: Path = {
 					token1: weth9,
@@ -661,7 +691,7 @@ describe('SwapTokensAndStakeDev', () => {
 						['address', 'uint24', 'address', 'uint24', 'address'],
 						[path.token1, path.fee1, path.token2, path.fee2, path.token3]
 					),
-					(depositAmount.sub(ecosystemFeeAmount)).sub(acutualFeeAmount)
+					depositAmount.sub(ecosystemFeeAmount).sub(acutualFeeAmount)
 				)
 
 				const amountIn = await cont.callStatic.getEstimatedTokensForDev(
@@ -717,7 +747,11 @@ describe('SwapTokensAndStakeDev', () => {
 				// Withdraw credit
 				await expect(cont.connect(gateway).claim(ethers.constants.AddressZero))
 					.to.emit(cont, 'Withdrawn')
-					.withArgs(gateway.address, ethers.constants.AddressZero, acutualFeeAmount)
+					.withArgs(
+						gateway.address,
+						ethers.constants.AddressZero,
+						acutualFeeAmount
+					)
 				// Check gateway credit has been deducted
 				expect(
 					await cont.gatewayFees(gateway.address, ethers.constants.AddressZero)

--- a/test/swap-tokens-stake-dev.ts
+++ b/test/swap-tokens-stake-dev.ts
@@ -192,15 +192,26 @@ describe('SwapTokensAndStakeDev', () => {
 				expect(sTokenOwner).to.equal(account1.address)
 				expect(sTokenPosition[1]).to.equal(amountOut)
 			})
-			it('should stake dev by swapping tokens and deduct gateway fee', async () => {
+			it('should stake dev by swapping tokens and deduct fees(gatewayfee < ecosystemFeeThreshold)', async () => {
 				// Get latest block
 				const block = await waffle.provider.getBlock('latest')
 				const deadline = block.timestamp + 300
 
-				const [cont] = await deployWithProxy<SwapTokensAndStakeDev>(
-					'SwapTokensAndStakeDev'
-				)
+				const [cont, owner, admin] =
+					await deployWithProxy<SwapTokensAndStakeDev>('SwapTokensAndStakeDev')
 				await cont.initialize(devAddress, lockupAddress, sTokensManagerAddress)
+
+				const owner1 = await cont.owner()
+				expect(owner1).to.equal(ethers.constants.AddressZero)
+
+				await cont.updateOwner(admin.address)
+				const owner2 = await cont.owner()
+				expect(owner2).to.equal(owner)
+
+				const contractOwner = await ethers.getSigner(owner)
+
+				const ecosystemFee = 250 // In basis points, so 2.5%
+				const ecosystemFeeThreshold = 8500 // In basis points, so 85%
 
 				// Get USDC via MATIC(Native Token) -> wMATIC -> USDC
 				await swapRouter.connect(account1).exactInputSingle(
@@ -218,6 +229,10 @@ describe('SwapTokensAndStakeDev', () => {
 						value: ethers.utils.parseEther('1700'),
 					}
 				)
+				await cont.connect(contractOwner).updateEcosystemFee(ecosystemFee)
+				await cont
+					.connect(contractOwner)
+					.updateEcosystemFeeThreshold(ecosystemFeeThreshold)
 
 				// Approve USDC
 				await usdcContract
@@ -226,8 +241,14 @@ describe('SwapTokensAndStakeDev', () => {
 
 				const gatewayFeeBasisPoints = 333 // In basis points, so 3.33%
 				const depositAmount = ethers.utils.parseUnits('1', 6)
-				const feeAmount = depositAmount.mul(gatewayFeeBasisPoints).div(10000)
-
+				const ecosystemFeeAmount =
+					gatewayFeeBasisPoints >= ecosystemFeeThreshold
+						? depositAmount.mul(ecosystemFee).div(10000)
+						: 0
+				const acutualFeeAmount = depositAmount
+					.sub(ecosystemFeeAmount)
+					.mul(gatewayFeeBasisPoints)
+					.div(10000)
 				const path: Path = {
 					token1: usdcAddress,
 					fee1: 500,
@@ -242,7 +263,7 @@ describe('SwapTokensAndStakeDev', () => {
 						['address', 'uint24', 'address', 'uint24', 'address'],
 						[path.token1, path.fee1, path.token2, path.fee2, path.token3]
 					),
-					depositAmount.sub(feeAmount)
+					depositAmount.sub(ecosystemFeeAmount).sub(acutualFeeAmount)
 				)
 
 				const amountIn = await cont.callStatic.getEstimatedTokensForDev(
@@ -293,13 +314,146 @@ describe('SwapTokensAndStakeDev', () => {
 
 				// Check gateway has been credited
 				expect(await cont.gatewayFees(gateway.address, usdcAddress)).to.eq(
-					feeAmount
+					acutualFeeAmount
 				)
 
 				// Withdraw credit
 				await expect(cont.connect(gateway).claim(usdcAddress))
 					.to.emit(cont, 'Withdrawn')
-					.withArgs(gateway.address, usdcAddress, feeAmount)
+					.withArgs(gateway.address, usdcAddress, acutualFeeAmount)
+
+				// Check gateway credit has been deducted
+				expect(await cont.gatewayFees(gateway.address, usdcAddress)).to.eq(0)
+			})
+			it('should stake dev by swapping tokens and deduct fees(gatewayfee >= ecosystemFeeThreshold)', async () => {
+				// Get latest block
+				const block = await waffle.provider.getBlock('latest')
+				const deadline = block.timestamp + 300
+
+				const [cont, owner, admin] =
+					await deployWithProxy<SwapTokensAndStakeDev>('SwapTokensAndStakeDev')
+				await cont.initialize(devAddress, lockupAddress, sTokensManagerAddress)
+
+				const owner1 = await cont.owner()
+				expect(owner1).to.equal(ethers.constants.AddressZero)
+
+				await cont.updateOwner(admin.address)
+				const owner2 = await cont.owner()
+				expect(owner2).to.equal(owner)
+
+				const contractOwner = await ethers.getSigner(owner)
+
+				const ecosystemFee = 250 // In basis points, so 2.5%
+				const ecosystemFeeThreshold = 8500 // In basis points, so 85%
+
+				// Get USDC via MATIC(Native Token) -> wMATIC -> USDC
+				await swapRouter.connect(account1).exactInputSingle(
+					{
+						tokenIn: weth9,
+						tokenOut: usdcAddress,
+						fee: 3000,
+						recipient: account1.address,
+						deadline,
+						amountIn: ethers.utils.parseEther('1700'),
+						amountOutMinimum: 0,
+						sqrtPriceLimitX96: 0,
+					},
+					{
+						value: ethers.utils.parseEther('1700'),
+					}
+				)
+				await cont.connect(contractOwner).updateEcosystemFee(ecosystemFee)
+				await cont
+					.connect(contractOwner)
+					.updateEcosystemFeeThreshold(ecosystemFeeThreshold)
+
+				// Approve USDC
+				await usdcContract
+					.connect(account1)
+					.approve(cont.address, ethers.utils.parseUnits('1900', 6))
+
+				const gatewayFeeBasisPoints = 8600 // In basis points, so 3.33%
+				const depositAmount = ethers.utils.parseUnits('1', 6)
+				const ecosystemFeeAmount =
+					gatewayFeeBasisPoints >= ecosystemFeeThreshold
+						? depositAmount.mul(ecosystemFee).div(10000)
+						: 0
+				const acutualFeeAmount = depositAmount
+					.sub(ecosystemFeeAmount)
+					.mul(gatewayFeeBasisPoints)
+					.div(10000)
+				const path: Path = {
+					token1: usdcAddress,
+					fee1: 500,
+					token2: wethAddress,
+					fee2: 10000,
+					token3: devAddress,
+				}
+
+				// Use callStaic to execute getEstimatedDevForUsdc as a read method
+				const amountOut = await cont.callStatic.getEstimatedDevForTokens(
+					ethers.utils.solidityPack(
+						['address', 'uint24', 'address', 'uint24', 'address'],
+						[path.token1, path.fee1, path.token2, path.fee2, path.token3]
+					),
+					depositAmount.sub(ecosystemFeeAmount).sub(acutualFeeAmount)
+				)
+
+				const amountIn = await cont.callStatic.getEstimatedTokensForDev(
+					ethers.utils.solidityPack(
+						['address', 'uint24', 'address', 'uint24', 'address'],
+						[path.token3, path.fee2, path.token2, path.fee1, path.token1]
+					),
+					amountOut
+				)
+
+				// Assuming only 1% slippage, it can be dynamic so need to make more better assertion
+				const expected = ethers.utils.parseUnits('1', 6)
+				expect(amountIn).to.lte(expected.sub(expected.mul(1).div(100)))
+				// STokenId = currentIndex + 1 will be minted.
+				let sTokenId: BigNumber = await sTokensManagerContract.currentIndex()
+				sTokenId = sTokenId.add(1)
+
+				await expect(
+					await cont
+						.connect(account1)
+						[
+							'swapTokensAndStakeDev(address,address,bytes,address,uint256,uint256,uint256,bytes32,address,uint256)'
+						](
+							account1.address,
+							usdcAddress,
+							ethers.utils.solidityPack(
+								['address', 'uint24', 'address', 'uint24', 'address'],
+								[path.token1, path.fee1, path.token2, path.fee2, path.token3]
+							),
+							propertyAddress,
+							ethers.utils.parseUnits('1', 6),
+							amountOut,
+							deadline,
+							ethers.utils.formatBytes32String(''),
+							gateway.address,
+							gatewayFeeBasisPoints
+						)
+				)
+					.to.emit(lockupContract, 'Lockedup')
+					.withArgs(cont.address, propertyAddress, amountOut, sTokenId)
+
+				const sTokenOwner = await sTokensManagerContract.ownerOf(sTokenId)
+				const sTokenPosition: number[] = await sTokensManagerContract.positions(
+					sTokenId
+				)
+				expect(sTokenOwner).to.equal(account1.address)
+				expect(sTokenPosition[1]).to.equal(amountOut)
+
+				// Check gateway has been credited
+				expect(await cont.gatewayFees(gateway.address, usdcAddress)).to.eq(
+					acutualFeeAmount
+				)
+
+				// Withdraw credit
+				await expect(cont.connect(gateway).claim(usdcAddress))
+					.to.emit(cont, 'Withdrawn')
+					.withArgs(gateway.address, usdcAddress, acutualFeeAmount)
 
 				// Check gateway credit has been deducted
 				expect(await cont.gatewayFees(gateway.address, usdcAddress)).to.eq(0)
@@ -370,19 +524,41 @@ describe('SwapTokensAndStakeDev', () => {
 					.to.emit(lockupContract, 'Lockedup')
 					.withArgs(cont.address, propertyAddress, amountOut, sTokenId)
 			})
-			it('should stake dev by swapping native token and deduct gateway fee', async () => {
+			it('should stake dev by swapping native token and deduct fees(gatewayfee < ecosystemFeeThreshold)', async () => {
 				// Get latest block
 				const block = await waffle.provider.getBlock('latest')
 				const deadline = block.timestamp + 300
 
 				const gatewayFeeBasisPoints = 333 // In basis points, so 3.33%
 				const depositAmount = ethers.utils.parseEther('1')
-				const feeAmount = depositAmount.mul(gatewayFeeBasisPoints).div(10000)
+				const ecosystemFee = 250 // In basis points, so 2.5%
+				const ecosystemFeeThreshold = 8500 // In basis points, so 85%
+				const ecosystemFeeAmount =
+					gatewayFeeBasisPoints >= ecosystemFeeThreshold
+						? depositAmount.mul(ecosystemFee).div(10000)
+						: 0
+				const acutualFeeAmount = depositAmount
+					.sub(ecosystemFeeAmount)
+					.mul(gatewayFeeBasisPoints)
+					.div(10000)
 
-				const [cont] = await deployWithProxy<SwapTokensAndStakeDev>(
-					'SwapTokensAndStakeDev'
-				)
+				const [cont, owner, admin] =
+					await deployWithProxy<SwapTokensAndStakeDev>('SwapTokensAndStakeDev')
 				await cont.initialize(devAddress, lockupAddress, sTokensManagerAddress)
+
+				const owner1 = await cont.owner()
+				expect(owner1).to.equal(ethers.constants.AddressZero)
+
+				await cont.updateOwner(admin.address)
+				const owner2 = await cont.owner()
+				expect(owner2).to.equal(owner)
+
+				const contractOwner = await ethers.getSigner(owner)
+
+				await cont.connect(contractOwner).updateEcosystemFee(ecosystemFee)
+				await cont
+					.connect(contractOwner)
+					.updateEcosystemFeeThreshold(ecosystemFeeThreshold)
 
 				const path: Path = {
 					token1: weth9,
@@ -398,7 +574,7 @@ describe('SwapTokensAndStakeDev', () => {
 						['address', 'uint24', 'address', 'uint24', 'address'],
 						[path.token1, path.fee1, path.token2, path.fee2, path.token3]
 					),
-					depositAmount.sub(feeAmount)
+					depositAmount.sub(ecosystemFeeAmount).sub(acutualFeeAmount)
 				)
 
 				const amountIn = await cont.callStatic.getEstimatedTokensForDev(
@@ -449,12 +625,132 @@ describe('SwapTokensAndStakeDev', () => {
 				// Check gateway has been credited
 				expect(
 					await cont.gatewayFees(gateway.address, ethers.constants.AddressZero)
-				).to.eq(feeAmount)
+				).to.eq(acutualFeeAmount)
 
 				// Withdraw credit
 				await expect(cont.connect(gateway).claim(ethers.constants.AddressZero))
 					.to.emit(cont, 'Withdrawn')
-					.withArgs(gateway.address, ethers.constants.AddressZero, feeAmount)
+					.withArgs(
+						gateway.address,
+						ethers.constants.AddressZero,
+						acutualFeeAmount
+					)
+				// Check gateway credit has been deducted
+				expect(
+					await cont.gatewayFees(gateway.address, ethers.constants.AddressZero)
+				).to.eq(0)
+			})
+			it('should stake dev by swapping native token and deduct fees(gatewayfee >= ecosystemFeeThreshold)', async () => {
+				// Get latest block
+				const block = await waffle.provider.getBlock('latest')
+				const deadline = block.timestamp + 300
+
+				const gatewayFeeBasisPoints = 8600 // In basis points, so 3.33%
+				const depositAmount = ethers.utils.parseEther('1')
+				const ecosystemFee = 250 // In basis points, so 2.5%
+				const ecosystemFeeThreshold = 8500 // In basis points, so 85%
+				const ecosystemFeeAmount =
+					gatewayFeeBasisPoints >= ecosystemFeeThreshold
+						? depositAmount.mul(ecosystemFee).div(10000)
+						: 0
+				const acutualFeeAmount = depositAmount
+					.sub(ecosystemFeeAmount)
+					.mul(gatewayFeeBasisPoints)
+					.div(10000)
+
+				const [cont, owner, admin] =
+					await deployWithProxy<SwapTokensAndStakeDev>('SwapTokensAndStakeDev')
+				await cont.initialize(devAddress, lockupAddress, sTokensManagerAddress)
+
+				const owner1 = await cont.owner()
+				expect(owner1).to.equal(ethers.constants.AddressZero)
+
+				await cont.updateOwner(admin.address)
+				const owner2 = await cont.owner()
+				expect(owner2).to.equal(owner)
+
+				const contractOwner = await ethers.getSigner(owner)
+
+				await cont.connect(contractOwner).updateEcosystemFee(ecosystemFee)
+				await cont
+					.connect(contractOwner)
+					.updateEcosystemFeeThreshold(ecosystemFeeThreshold)
+
+				const path: Path = {
+					token1: weth9,
+					fee1: 500,
+					token2: wethAddress,
+					fee2: 10000,
+					token3: devAddress,
+				}
+
+				// Use callStaic to execute getEstimatedDevForUsdc as a read method
+				const amountOut = await cont.callStatic.getEstimatedDevForTokens(
+					ethers.utils.solidityPack(
+						['address', 'uint24', 'address', 'uint24', 'address'],
+						[path.token1, path.fee1, path.token2, path.fee2, path.token3]
+					),
+					depositAmount.sub(ecosystemFeeAmount).sub(acutualFeeAmount)
+				)
+
+				const amountIn = await cont.callStatic.getEstimatedTokensForDev(
+					ethers.utils.solidityPack(
+						['address', 'uint24', 'address', 'uint24', 'address'],
+						[path.token3, path.fee2, path.token2, path.fee1, path.token1]
+					),
+					amountOut
+				)
+
+				// Assuming only 1% slippage, it can be dynamic so need to make more better assertion
+				const expected = ethers.utils.parseEther('1')
+				expect(amountIn).to.lte(expected.sub(expected.mul(1).div(100)))
+				// STokenId = currentIndex + 1 will be minted.
+				let sTokenId: BigNumber = await sTokensManagerContract.currentIndex()
+				sTokenId = sTokenId.add(1)
+
+				await expect(
+					await cont
+						.connect(account1)
+						[
+							'swapTokensAndStakeDev(address,bytes,address,uint256,uint256,bytes32,address,uint256)'
+						](
+							account1.address,
+							ethers.utils.solidityPack(
+								['address', 'uint24', 'address', 'uint24', 'address'],
+								[path.token1, path.fee1, path.token2, path.fee2, path.token3]
+							),
+							propertyAddress,
+							amountOut,
+							deadline,
+							ethers.utils.formatBytes32String(''),
+							gateway.address,
+							gatewayFeeBasisPoints,
+							{
+								value: ethers.utils.parseEther('1'),
+							}
+						)
+				)
+					.to.emit(lockupContract, 'Lockedup')
+					.withArgs(cont.address, propertyAddress, amountOut, sTokenId)
+				const sTokenOwner = await sTokensManagerContract.ownerOf(sTokenId)
+				const sTokenPosition: number[] = await sTokensManagerContract.positions(
+					sTokenId
+				)
+				expect(sTokenOwner).to.equal(account1.address)
+				expect(sTokenPosition[1]).to.equal(amountOut)
+				// Check gateway has been credited
+				expect(
+					await cont.gatewayFees(gateway.address, ethers.constants.AddressZero)
+				).to.eq(acutualFeeAmount)
+
+				// Withdraw credit
+				await expect(cont.connect(gateway).claim(ethers.constants.AddressZero))
+					.to.emit(cont, 'Withdrawn')
+					.withArgs(
+						gateway.address,
+						ethers.constants.AddressZero,
+						acutualFeeAmount
+					)
 				// Check gateway credit has been deducted
 				expect(
 					await cont.gatewayFees(gateway.address, ethers.constants.AddressZero)

--- a/test/swap-tokens-stake-dev.ts
+++ b/test/swap-tokens-stake-dev.ts
@@ -11,6 +11,9 @@ import * as dotenv from 'dotenv'
 
 dotenv.config()
 
+const RPC_KEY =
+	typeof process.env.ALCHEMY_KEY === 'undefined' ? '' : process.env.ALCHEMY_KEY
+
 use(solidity)
 
 type Path = {
@@ -40,13 +43,12 @@ describe('SwapTokensAndStakeDev', () => {
 	let swapRouter: ISwapRouter
 
 	beforeEach(async function () {
-		this.timeout(60000)
 		await ethers.provider.send('hardhat_reset', [
 			{
 				forking: {
 					jsonRpcUrl:
-						'https://polygon-mainnet.infura.io/v3/265bfd78394d426694f7c749be00f7fc',
-					blockNumber: 45237517,
+						'https://polygon-mainnet.g.alchemy.com/v2/' + RPC_KEY,
+						blockNumber: 58590400,
 				},
 			},
 		])
@@ -77,6 +79,7 @@ describe('SwapTokensAndStakeDev', () => {
 			'contracts/interfaces/ISTokensManager.sol:ISTokensManager',
 			sTokensManagerAddress
 		)
+		this.timeout(60000)
 	})
 	describe('SwapTokensAndStakeDev', () => {
 		describe('initialize', () => {

--- a/test/swap-usdc-stake-v3-polygon.ts
+++ b/test/swap-usdc-stake-v3-polygon.ts
@@ -29,7 +29,8 @@ describe('SwapUsdcAndStakeV3 Polygon', () => {
 	let usdcContract: Contract
 	let swapRouter: ISwapRouter
 
-	beforeEach(async () => {
+	beforeEach(async function () {
+		this.timeout(60000);
 		await ethers.provider.send('hardhat_reset', [
 			{
 				forking: {

--- a/test/swap-usdc-stake-v3-polygon.ts
+++ b/test/swap-usdc-stake-v3-polygon.ts
@@ -8,6 +8,9 @@ import * as dotenv from 'dotenv'
 
 dotenv.config()
 
+const RPC_KEY =
+	typeof process.env.ALCHEMY_KEY === 'undefined' ? '' : process.env.ALCHEMY_KEY
+
 use(solidity)
 
 describe('SwapUsdcAndStakeV3 Polygon', () => {
@@ -30,13 +33,12 @@ describe('SwapUsdcAndStakeV3 Polygon', () => {
 	let swapRouter: ISwapRouter
 
 	beforeEach(async function () {
-		this.timeout(60000)
 		await ethers.provider.send('hardhat_reset', [
 			{
 				forking: {
 					jsonRpcUrl:
-						'https://polygon-mainnet.infura.io/v3/265bfd78394d426694f7c749be00f7fc',
-					blockNumber: 44358690,
+						'https://polygon-mainnet.g.alchemy.com/v2/' + RPC_KEY,
+						blockNumber: 58590400,
 				},
 			},
 		])
@@ -78,6 +80,7 @@ describe('SwapUsdcAndStakeV3 Polygon', () => {
 			'contracts/interfaces/ISTokensManager.sol:ISTokensManager',
 			sTokensManagerAddress
 		)
+		this.timeout(60000)
 	})
 	describe('swap usdc for dev', () => {
 		it('should stake dev for usdc', async () => {

--- a/test/swap-usdc-stake-v3-polygon.ts
+++ b/test/swap-usdc-stake-v3-polygon.ts
@@ -36,9 +36,8 @@ describe('SwapUsdcAndStakeV3 Polygon', () => {
 		await ethers.provider.send('hardhat_reset', [
 			{
 				forking: {
-					jsonRpcUrl:
-						'https://polygon-mainnet.g.alchemy.com/v2/' + RPC_KEY,
-						blockNumber: 58590400,
+					jsonRpcUrl: 'https://polygon-mainnet.g.alchemy.com/v2/' + RPC_KEY,
+					blockNumber: 58590400,
 				},
 			},
 		])

--- a/test/swap-usdc-stake-v3-polygon.ts
+++ b/test/swap-usdc-stake-v3-polygon.ts
@@ -30,7 +30,7 @@ describe('SwapUsdcAndStakeV3 Polygon', () => {
 	let swapRouter: ISwapRouter
 
 	beforeEach(async function () {
-		this.timeout(60000);
+		this.timeout(60000)
 		await ethers.provider.send('hardhat_reset', [
 			{
 				forking: {


### PR DESCRIPTION
Ecosystem Fees will be introduced as a mechanism to ensure that both users who wish to intentionally utilize staking and users who wish to use classic payments instead of staking can use Clubs and that the DEV ecosystem grows.

Setting the minimum membership staking ratio to 0. And instead of staking, SwapTokensAndStakeDev contract will deposit (_deposit) 2.5% of the transferred value to the owner if the gatewayFee is greater than or equal to 85% (= Staking ratio of 15% or less).

If the staking ratio is greater than 15%, Ecosystem Fees are 0. Therefore, Ecosystem Fees do not impact for existing Clubs that intentionally employ high staking ratios.

SwapTokensAndStakeDev contract will be having 2 new types of state variables. And only the owner can change these values.

Proposed fees:
ecosystemFee - 2.5% (250)
ecosystemFeeThreshold - 85% (8500)